### PR TITLE
[FIX] Localization keys are now translated in the Select Provider GUI

### DIFF
--- a/src/main/java/com/example/ae2_auto_pattern_upload/client/gui/GuiProviderSelect.java
+++ b/src/main/java/com/example/ae2_auto_pattern_upload/client/gui/GuiProviderSelect.java
@@ -6,6 +6,7 @@ import com.example.ae2_auto_pattern_upload.util.RecipeNameUtil;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextComponentString;
 
 import java.io.IOException;
@@ -371,7 +372,7 @@ public class GuiProviderSelect extends GuiScreen {
         }
     }
 
-    private String translate(String key) {
-        return net.minecraft.client.resources.I18n.format(key);
+    public static String translate(String key) {
+        return I18n.format(key);
     }
 }

--- a/src/main/java/com/example/ae2_auto_pattern_upload/network/ProvidersListS2CPacket.java
+++ b/src/main/java/com/example/ae2_auto_pattern_upload/network/ProvidersListS2CPacket.java
@@ -12,6 +12,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.example.ae2_auto_pattern_upload.client.gui.GuiProviderSelect.translate;
+
 /**
  * S2C: 返回供应器列表到客户端
  */
@@ -85,7 +87,9 @@ public class ProvidersListS2CPacket implements IMessage {
         if (name == null || name.isEmpty()) {
             return DEFAULT_PROVIDER_NAME;
         }
-        return name;
+        String namedKey = name + ".name";
+        String translated = translate(namedKey);
+        return translated.equals(namedKey) ? translate(name) : translated;
     }
 
     public List<Long> getIds() {


### PR DESCRIPTION
before:
<img width="1205" height="704" alt="изображение" src="https://github.com/user-attachments/assets/e415a3b6-3898-450a-846e-2f57ee8f2b6e" />


now:
<img width="1272" height="749" alt="изображение" src="https://github.com/user-attachments/assets/e9aa1d00-db5f-4952-9793-2fd85b1251c4" />
